### PR TITLE
Force Latitude/Longitude lookup if not in response

### DIFF
--- a/lib/melissa_data.rb
+++ b/lib/melissa_data.rb
@@ -4,9 +4,11 @@ require "melissa_data/web_smart/response_processor"
 require "melissa_data/web_smart/client"
 require "melissa_data/web_smart/property_api"
 require "melissa_data/config"
+require "melissa_data/geo_lookup/geocoder"
 
 require 'rest-client'
 require 'nokogiri'
+require 'geokit'
 
 module MelissaData
   include MelissaData::Config

--- a/lib/melissa_data/config.rb
+++ b/lib/melissa_data/config.rb
@@ -6,16 +6,18 @@ module MelissaData
 
     # @!attribute web_smart_id
     # @return [String] web smart id to be used
-    attr_accessor :web_smart_id
+    attr_accessor :web_smart_id, :google_maps_api_key
 
     # Configures web_smart_id and property_api_url
     #   Usage example:
     #     MelissaData.configure do |config|
-    #       config.web_smart_id = ENV['MELISSA_DATA_WEB_SMART_ID']
+    #       config.web_smart_id        = ENV['MELISSA_DATA_WEB_SMART_ID']
+    #       config.google_maps_api_key = ENV['MELISSA_DATA_WEB_SMART_ID']
     #     end
     #
     #   Alternate way:
-    #     MelissaData.web_smart_id = ENV['MELISSA_DATA_WEB_SMART_ID']
+    #     MelissaData.web_smart_id        = ENV['MELISSA_DATA_WEB_SMART_ID']
+    #     MelissaData.google_maps_api_key = ENV['MELISSA_DATA_WEB_SMART_ID']
     #
     # @param <api_key> [String] web smart id to use
     def configure

--- a/lib/melissa_data/geo_lookup/geocoder.rb
+++ b/lib/melissa_data/geo_lookup/geocoder.rb
@@ -1,0 +1,22 @@
+module MelissaData
+  module GeoLookup
+    module Geocoder
+      extend self
+
+      def address_to_coordinates(address)
+        Geokit::Geocoders::GoogleGeocoder.api_key = MelissaData.google_maps_api_key
+        lat_long = Geokit::Geocoders::GoogleGeocoder.geocode(address)
+          .ll
+          .split(",")
+          .map(&:to_f)
+          { latitude: lat_long.first, longitude: lat_long.last }
+      end
+
+      def coordinates?(response)
+        lat = response[:property_address][:latitude]
+        long = response[:property_address][:longitude]
+        lat != nil && long != nil
+      end
+    end
+  end
+end

--- a/lib/melissa_data/version.rb
+++ b/lib/melissa_data/version.rb
@@ -1,3 +1,3 @@
 module MelissaData
-  VERSION = "0.2.7"
+  VERSION = "0.2.8"
 end

--- a/lib/melissa_data/web_smart/client.rb
+++ b/lib/melissa_data/web_smart/client.rb
@@ -9,11 +9,15 @@ module MelissaData
       end
 
       def property_by_apn(fips:, apn:)
-        process(@client.property_by_apn(fips: fips, apn: apn), 'property')
+        res = process(@client.property_by_apn(fips: fips, apn: apn), 'property')
+        add_coordinates(res) unless MelissaData::GeoLookup::Geocoder.coordinates? res
+        res
       end
 
       def property_by_address_key(address_key:)
-        process(@client.property_by_address_key(address_key: address_key), 'property')
+        res = process(@client.property_by_address_key(address_key: address_key), 'property')
+        add_coordinates(res) unless MelissaData::GeoLookup::Geocoder.coordinates? res
+        res
       end
 
       def address(address:, city:, state:, zip:, country: "USA")
@@ -23,6 +27,16 @@ module MelissaData
                                              zip: zip,
                                              country: country))
         process(resp, 'address')
+      end
+
+      def add_coordinates(response)
+        addr  = response[:property_address][:address]
+        city  = response[:property_address][:city]
+        state = response[:property_address][:state]
+        zip   = response[:property_address][:zip]
+        full_address = "#{addr}, #{city}, #{state}, #{zip}"
+        MelissaData::GeoLookup::Geocoder
+          .address_to_coordinates(full_address)
       end
     end
   end

--- a/melissa_data.gemspec
+++ b/melissa_data.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "nokogiri"
   spec.add_runtime_dependency "rest-client"
+  spec.add_runtime_dependency "geokit"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/melissa_data/geo_lookup/geocoder_spec.rb
+++ b/spec/melissa_data/geo_lookup/geocoder_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe MelissaData::GeoLookup::Geocoder do
+  before do allow_any_instance_of(MelissaData::GeoLookup::Geocoder)
+             .to receive(:address_to_coordinates)
+             .and_return({ latitude: 41.377552, longitude: -83.13062699999999 })
+  end
+
+  it "can turn an address into a lat/long coordinates" do
+    geocoder = MelissaData::GeoLookup::Geocoder
+    res = geocoder.address_to_coordinates("159 thomas drive, fremont, ohio")
+    expected = { latitude: 41.377552, longitude: -83.13062699999999 }
+    expect(res).to eq expected
+  end
+end


### PR DESCRIPTION
# Functionality

Internally, the gem now will look up the latitude and longitude coordinates of a given property through Google's geocoding API. This requires a single piece of configuration for things to work. Like you would set your `web_smart_id` for the API functions, it is called as:

``` ruby
MelissaData.web_smart_id = 'your_id'
```

The same is done with the Google Maps API key:

``` ruby
MelissaData.google_maps_api_key = 'your_key'
```

Or the alternative config,

``` ruby
MelissaData.configure do |config|
  config.web_smart_id         = ENV['MELISSA_DATA_WEB_SMART_ID']
  config.google_maps_api_key = ENV['MELISSA_DATA_WEB_SMART_ID']
end
```

There are no extraneous API changes
