### PR TITLE
Meaningfully Handle Bad APN's

### DIFF
--- a/lib/melissa_data/geo_lookup/geocoder.rb
+++ b/lib/melissa_data/geo_lookup/geocoder.rb
@@ -14,9 +14,18 @@ module MelissaData
       end
 
       def coordinates?(response)
-        lat = response[:property_address][:latitude]
-        long = response[:property_address][:longitude]
-        lat != nil && long != nil
+        if !response[:errors]
+          lat = response.fetch(:property_address)[:latitude]
+          long =response.fetch(:property_address)[:longitude]
+          lat != nil && long != nil
+        else
+          false
+        end
+      end
+
+      def authenticate
+        Geokit::Geocoders::GoogleGeocoder.api_key = MelissaData.google_maps_api_key
+        Geokit::Geocoders::GoogleGeocoder.api_key
       end
 
       def authenticate


### PR DESCRIPTION
# Writing up now...
# Meaningfully Handle Bad APN's

Previously, if we returned a response that simply had no proper results, it would erroneously fire the method to add lat/long coordinates and result in a nil bleeding through upwards.
Now, we check explicitly for errors and raise if we do not have the necessary pieces like so:

``` ruby
...
        if !response[:errors]
          lat = response.fetch(:property_address)[:latitude]
          long =response.fetch(:property_address)[:longitude]
          lat != nil && long != nil
        else
          false
        end
...
```
