### PR TITLE
Support V4 api changes

### DIFF
--- a/lib/melissa_data.rb
+++ b/lib/melissa_data.rb
@@ -7,7 +7,6 @@ require "melissa_data/web_smart/property_api"
 require "melissa_data/config"
 require "melissa_data/geo_lookup/geocoder"
 
-require 'rest-client'
 require 'geokit'
 
 module MelissaData

--- a/lib/melissa_data.rb
+++ b/lib/melissa_data.rb
@@ -1,3 +1,4 @@
+require "active_support/core_ext/hash"
 require "melissa_data/version"
 require "melissa_data/web_smart/xml"
 require "melissa_data/web_smart/response_processor"
@@ -7,7 +8,6 @@ require "melissa_data/config"
 require "melissa_data/geo_lookup/geocoder"
 
 require 'rest-client'
-require 'nokogiri'
 require 'geokit'
 
 module MelissaData

--- a/lib/melissa_data/geo_lookup/geocoder.rb
+++ b/lib/melissa_data/geo_lookup/geocoder.rb
@@ -14,7 +14,7 @@ module MelissaData
       end
 
       def coordinates?(response)
-        if !response[:errors]
+        if !response[:errors] && !response[:property_address]&.empty?
           lat = response.fetch(:property_address)[:latitude]
           long =response.fetch(:property_address)[:longitude]
           lat != nil && long != nil

--- a/lib/melissa_data/web_smart/client.rb
+++ b/lib/melissa_data/web_smart/client.rb
@@ -24,7 +24,7 @@ module MelissaData
 
       def resolve_response
         return @response unless success?
-        add_coordinates(@response) unless MelissaData::GeoLookup::Geocoder.coordinates? @response
+        add_coordinates(@response[:records].first) unless MelissaData::GeoLookup::Geocoder.coordinates? @response[:records].first
         @response
       end
 
@@ -42,9 +42,11 @@ module MelissaData
         city  = response.dig(:property_address, :city)
         state = response.dig(:property_address, :state)
         zip   = response.dig(:property_address, :zip)
-        full_address = "#{addr}, #{city}, #{state}, #{zip}"
-        MelissaData::GeoLookup::Geocoder
-          .address_to_coordinates(full_address)
+
+        if addr && city && state && zip
+          full_address = "#{addr}, #{city}, #{state}, #{zip}"
+          MelissaData::GeoLookup::Geocoder.address_to_coordinates(full_address)
+        end
       end
     end
   end

--- a/lib/melissa_data/web_smart/property_api.rb
+++ b/lib/melissa_data/web_smart/property_api.rb
@@ -1,25 +1,26 @@
 require 'rest-client'
-require 'nokogiri'
 require 'json'
 
 module MelissaData
   module WebSmart
     class PropertyAPI
       def property_by_apn(fips:, apn:)
-        resp = RestClient.get('https://property.melissadata.net/v3/REST/Service.svc/doLookup/',
+        resp = RestClient.get('https://property.melissadata.net/v4/WEB/LookupProperty/',
                              { params: { id: MelissaData.web_smart_id,
                                          fips: fips,
                                          apn: apn,
-                                         opt: "True" } })
-        PropertyXMLParser.new(Nokogiri::XML(resp)).parse
+                                         format: 'json' } })
+        res = JSON.parse(resp.body).deep_transform_keys(&:underscore)
+        res&.with_indifferent_access
       end
 
       def property_by_address_key(address_key:)
-        resp = RestClient.get('https://property.melissadata.net/v3/REST/Service.svc/doLookup/',
+        resp = RestClient.get('https://property.melissadata.net/v4/WEB/LookupProperty/',
                              { params: { id: MelissaData.web_smart_id,
                                          AddressKey: address_key,
-                                         opt: "True" } })
-        PropertyXMLParser.new(Nokogiri::XML(resp)).parse
+                                         format: 'json' } })
+        res = JSON.parse(resp.body).deep_transform_keys(&:underscore)
+        res&.with_indifferent_access
       end
 
       def address(address:, city:, state:, zip:, country:)

--- a/lib/melissa_data/web_smart/property_api.rb
+++ b/lib/melissa_data/web_smart/property_api.rb
@@ -1,41 +1,65 @@
-require 'rest-client'
+require 'faraday'
+require 'typhoeus'
 require 'json'
 
 module MelissaData
   module WebSmart
     class PropertyAPI
+      USER_AGENT = "MelissaData-Rubygem/#{MelissaData::VERSION}"
+      BASE_URL = 'https://property.melissadata.net'
+
+      def default_connection(url = BASE_URL, json_headers: false)
+        Faraday.new(url: url) do |conn|
+          conn.response :logger
+          conn.headers[:user_agent] = USER_AGENT
+
+          if json_headers
+            conn.headers['Content-Type'] = 'application/json'
+            conn.headers['Accept'] = 'application/json'
+          end
+
+          conn.adapter :typhoeus
+        end
+      end
+
       def property_by_apn(fips:, apn:)
-        resp = RestClient.get('https://property.melissadata.net/v4/WEB/LookupProperty/',
-                             { params: { id: MelissaData.web_smart_id,
-                                         fips: fips,
-                                         apn: apn,
-                                         format: 'json' } })
-        res = JSON.parse(resp.body).deep_transform_keys(&:underscore)
+        raw = default_connection(BASE_URL).get '/v4/WEB/LookupProperty/', {
+          id: MelissaData.web_smart_id,
+          fips: fips,
+          apn: apn,
+          format: 'json'
+        }
+
+        res = JSON.parse(raw.body).deep_transform_keys(&:underscore)
         res&.with_indifferent_access
       end
 
       def property_by_address_key(address_key:)
-        resp = RestClient.get('https://property.melissadata.net/v4/WEB/LookupProperty/',
-                             { params: { id: MelissaData.web_smart_id,
-                                         AddressKey: address_key,
-                                         format: 'json' } })
-        res = JSON.parse(resp.body).deep_transform_keys(&:underscore)
+        raw = default_connection(BASE_URL).get '/v4/WEB/LookupProperty/', {
+          id: MelissaData.web_smart_id,
+          AddressKey: address_key,
+          format: 'json'
+        }
+
+        res = JSON.parse(raw.body).deep_transform_keys(&:underscore)
         res&.with_indifferent_access
       end
 
       def address(address:, city:, state:, zip:, country:)
-        resp = JSON.parse(RestClient.get("https://personator.melissadata.net/v3/WEB/ContactVerify/doContactVerify",
-                                         { params: { id: MelissaData.web_smart_id,
-                                                     Actions: "Check",
-                                                     a1: address,
-                                                     city: city,
-                                                     state: state,
-                                                     postal: zip,
-                                                     ctry: country,
-                                                     AdvancedAddressCorrection: "on",},
-                                           accept: :json,
-                                           content_type: :json }))
-        resp["Records"].first
+        raw = default_connection(BASE_URL, json_headers: true)
+          .get '/v3/WEB/ContactVerify/doContactVerify', {
+            id: MelissaData.web_smart_id,
+            Actions: 'Check',
+            a1: address,
+            city: city,
+            state: state,
+            postal: zip,
+            ctry: country,
+            AdvancedAddressCorrection: 'on'
+        }
+
+        res = JSON.parse(raw.body).deep_transform_keys(&:underscore)
+        res&.with_indifferent_access[:records]&.first
       end
     end
   end

--- a/lib/melissa_data/web_smart/response_processor.rb
+++ b/lib/melissa_data/web_smart/response_processor.rb
@@ -31,9 +31,9 @@ module MelissaData
       def codes(response, resp_type)
         case resp_type
         when 'property'
-          response[:result][:code].split(",")
+          response[:records].first[:results].split(',')
         when 'address'
-          response[:results].split(",")
+          response[:records].first[:results].split(',')
         end
       end
 

--- a/melissa_data.gemspec
+++ b/melissa_data.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_runtime_dependency "rest-client"
   spec.add_runtime_dependency "geokit"
   spec.add_runtime_dependency "activesupport"
+  spec.add_runtime_dependency 'faraday', '~> 0.15.0'
+  spec.add_runtime_dependency 'typhoeus', '~> 1.3.0'
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/melissa_data.gemspec
+++ b/melissa_data.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_runtime_dependency "nokogiri"
   spec.add_runtime_dependency "rest-client"
   spec.add_runtime_dependency "geokit"
 

--- a/melissa_data.gemspec
+++ b/melissa_data.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rest-client"
   spec.add_runtime_dependency "geokit"
+  spec.add_runtime_dependency "activesupport"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/melissa_data.gemspec
+++ b/melissa_data.gemspec
@@ -20,14 +20,14 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_runtime_dependency "geokit"
-  spec.add_runtime_dependency "activesupport"
+  spec.add_runtime_dependency 'geokit'
+  spec.add_runtime_dependency 'activesupport', '~> 4.2.2'
   spec.add_runtime_dependency 'faraday', '~> 0.15.0'
   spec.add_runtime_dependency 'typhoeus', '~> 1.3.0'
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.3"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "webmock"
+  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.3'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
- [x] Support for `LookupProperty` (v4 API) endpoint
- [x] Remove `Nokogiri`, 'rest-client'
- [x] Add `ActiveSupport`, 'Typhoeus', 'Faraday'
- [x] Bump version to `1.0.0`

##
- [x] Ready